### PR TITLE
ensure 'end' is called, regardless of errors

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -200,14 +200,15 @@ class Crawler extends EventEmitter {
     }
 
     _generateEvents(eventsType, data) {
+        this.countOfProcessedUrls++;
+        
         if(eventsType === 'data') {
-            this.countOfProcessedUrls++;
             this.emit('data', {url: data.currentUrl, result: data.result});
-
-            if(this.waitingOfConnection === 0 && this.countOfProcessedUrls === this.foundLinks.size) this.emit('end');
         } else if(eventsType === 'error') {
             this.emit('error', new Error(`Error in ${data.currentUrl}: ${data.error}`));
         }
+        
+        if(this.waitingOfConnection === 0 && this.countOfProcessedUrls === this.foundLinks.size) this.emit('end');
     }
 }
 


### PR DESCRIPTION
This commit rearranges the lines in _generateEvents, ensuring end event is emitted.